### PR TITLE
Implement Flask backend with login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+FLASK_ENV=development
+SECRET_KEY=changeme
+DATABASE_URL=postgresql://user:password@localhost:5432/buses

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
-# rutasnicaragua
-todas las rutas y viejas de nicaragua en una sola pagina 
+# Rutas Nicaragua Backend
+
+Este proyecto provee un backend en Flask para importar y consultar rutas de buses de Nicaragua.
+
+## Instalación
+
+```bash
+pip install -r requirements.txt
+cp .env.example .env
+```
+
+## Uso
+
+- `python run.py` inicia la aplicación.
+- `python scripts/import_gtfs.py` importa archivos GTFS desde `data/gtfs/<REGION>`.
+- `python scripts/import_json.py archivo.json REGION` carga rutas desde un JSON estructurado.
+
+La API expone los siguientes endpoints:
+
+- `/api/regiones`
+- `/api/rutas?region=Estelí`
+- `/api/paradas?ruta=0501`
+
+El sistema incluye autenticación mejorada con contraseñas hasheadas usando `werkzeug.security`.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,27 @@
+import os
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from flask_login import LoginManager
+from dotenv import load_dotenv
+
+load_dotenv()
+
+db = SQLAlchemy()
+login_manager = LoginManager()
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.getenv('DATABASE_URL')
+    app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'secret')
+
+    db.init_app(app)
+    login_manager.init_app(app)
+
+    from .routes import api_bp
+    from .auth import auth_bp
+
+    app.register_blueprint(api_bp, url_prefix='/api')
+    app.register_blueprint(auth_bp, url_prefix='/auth')
+
+    return app

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,24 @@
+from flask import Blueprint, request, jsonify
+from flask_login import login_user, logout_user, login_required
+from .models import User, db
+
+auth_bp = Blueprint('auth', __name__)
+
+@auth_bp.route('/login', methods=['POST'])
+def login():
+    data = request.get_json() or {}
+    username = data.get('username')
+    password = data.get('password')
+    if not username or not password:
+        return jsonify({'error': 'Missing credentials'}), 400
+    user = User.query.filter_by(username=username).first()
+    if user and user.check_password(password):
+        login_user(user)
+        return jsonify({'message': 'Logged in'})
+    return jsonify({'error': 'Invalid credentials'}), 401
+
+@auth_bp.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return jsonify({'message': 'Logged out'})

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,56 @@
+from . import db, login_manager
+from flask_login import UserMixin
+from werkzeug.security import generate_password_hash, check_password_hash
+
+class Region(db.Model):
+    __tablename__ = 'regions'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), nullable=False, unique=True)
+
+class Route(db.Model):
+    __tablename__ = 'routes'
+    route_id = db.Column(db.String(64), primary_key=True)
+    region_id = db.Column(db.Integer, db.ForeignKey('regions.id'))
+    short_name = db.Column(db.String(50))
+    long_name = db.Column(db.String(100))
+    type = db.Column(db.String(20))
+
+class Stop(db.Model):
+    __tablename__ = 'stops'
+    stop_id = db.Column(db.String(64), primary_key=True)
+    region_id = db.Column(db.Integer, db.ForeignKey('regions.id'))
+    name = db.Column(db.String(100))
+    lat = db.Column(db.Float)
+    lon = db.Column(db.Float)
+
+class Trip(db.Model):
+    __tablename__ = 'trips'
+    trip_id = db.Column(db.String(64), primary_key=True)
+    route_id = db.Column(db.String(64), db.ForeignKey('routes.route_id'))
+    service_id = db.Column(db.String(64))
+    headsign = db.Column(db.String(100))
+
+class StopTime(db.Model):
+    __tablename__ = 'stop_times'
+    id = db.Column(db.Integer, primary_key=True)
+    trip_id = db.Column(db.String(64), db.ForeignKey('trips.trip_id'))
+    arrival_time = db.Column(db.String(8))
+    departure_time = db.Column(db.String(8))
+    stop_id = db.Column(db.String(64), db.ForeignKey('stops.stop_id'))
+    sequence = db.Column(db.Integer)
+
+class User(UserMixin, db.Model):
+    __tablename__ = 'users'
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+
+    def set_password(self, password):
+        self.password_hash = generate_password_hash(password)
+
+    def check_password(self, password):
+        return check_password_hash(self.password_hash, password)
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,40 @@
+from flask import Blueprint, jsonify, request
+from .models import db, Region, Route, Stop
+
+api_bp = Blueprint('api', __name__)
+
+@api_bp.route('/regiones')
+def regiones():
+    regions = Region.query.all()
+    return jsonify([{'id': r.id, 'name': r.name} for r in regions])
+
+@api_bp.route('/rutas')
+def rutas():
+    region_name = request.args.get('region')
+    query = Route.query
+    if region_name:
+        region = Region.query.filter_by(name=region_name).first()
+        if region:
+            query = query.filter_by(region_id=region.id)
+        else:
+            return jsonify([])
+    routes = query.all()
+    return jsonify([
+        {
+            'route_id': r.route_id,
+            'short_name': r.short_name,
+            'long_name': r.long_name,
+            'type': r.type
+        } for r in routes
+    ])
+
+@api_bp.route('/paradas')
+def paradas():
+    route_id = request.args.get('ruta')
+    if not route_id:
+        return jsonify([])
+    stops = Stop.query.filter_by(region_id=Route.query.filter_by(route_id=route_id).first().region_id).all()
+    return jsonify([
+        {'stop_id': s.stop_id, 'name': s.name, 'lat': s.lat, 'lon': s.lon}
+        for s in stops
+    ])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask
+Flask-SQLAlchemy
+psycopg2-binary
+python-dotenv
+Flask-Login
+pandas

--- a/run.py
+++ b/run.py
@@ -1,0 +1,6 @@
+from app import create_app
+
+app = create_app()
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/scripts/import_gtfs.py
+++ b/scripts/import_gtfs.py
@@ -1,0 +1,65 @@
+import csv
+import os
+import pandas as pd
+from app import create_app, db
+from app.models import Region, Route, Stop, Trip, StopTime
+
+app = create_app()
+
+GTFS_FOLDER = 'data/gtfs'
+
+
+def load_gtfs(region_name):
+    region = Region.query.filter_by(name=region_name).first()
+    if not region:
+        region = Region(name=region_name)
+        db.session.add(region)
+        db.session.commit()
+
+    files = {
+        'routes': 'routes.txt',
+        'stops': 'stops.txt',
+        'trips': 'trips.txt',
+        'stop_times': 'stop_times.txt'
+    }
+    for key, fname in files.items():
+        path = os.path.join(GTFS_FOLDER, region_name, fname)
+        if not os.path.exists(path):
+            continue
+        df = pd.read_csv(path)
+        if key == 'routes':
+            for _, row in df.iterrows():
+                r = Route(route_id=row['route_id'], region_id=region.id,
+                          short_name=row.get('route_short_name'),
+                          long_name=row.get('route_long_name'),
+                          type=row.get('route_type'))
+                db.session.merge(r)
+        elif key == 'stops':
+            for _, row in df.iterrows():
+                s = Stop(stop_id=row['stop_id'], region_id=region.id,
+                         name=row.get('stop_name'),
+                         lat=row.get('stop_lat'),
+                         lon=row.get('stop_lon'))
+                db.session.merge(s)
+        elif key == 'trips':
+            for _, row in df.iterrows():
+                t = Trip(trip_id=row['trip_id'], route_id=row['route_id'],
+                         service_id=row.get('service_id'),
+                         headsign=row.get('trip_headsign'))
+                db.session.merge(t)
+        elif key == 'stop_times':
+            for _, row in df.iterrows():
+                st = StopTime(trip_id=row['trip_id'],
+                              arrival_time=row.get('arrival_time'),
+                              departure_time=row.get('departure_time'),
+                              stop_id=row['stop_id'],
+                              sequence=row.get('stop_sequence'))
+                db.session.merge(st)
+    db.session.commit()
+    print(f"Imported GTFS for {region_name}")
+
+
+if __name__ == '__main__':
+    with app.app_context():
+        region = os.environ.get('REGION', 'Managua')
+        load_gtfs(region)

--- a/scripts/import_json.py
+++ b/scripts/import_json.py
@@ -1,0 +1,37 @@
+import json
+import sys
+from app import create_app, db
+from app.models import Region, Route, Stop
+
+app = create_app()
+
+
+def load_json(path, region_name):
+    with open(path) as f:
+        data = json.load(f)
+
+    region = Region.query.filter_by(name=region_name).first()
+    if not region:
+        region = Region(name=region_name)
+        db.session.add(region)
+        db.session.commit()
+
+    for route in data.get('routes', []):
+        r = Route(route_id=route['id'], region_id=region.id,
+                  short_name=route.get('short_name'),
+                  long_name=route.get('long_name'),
+                  type=route.get('type'))
+        db.session.merge(r)
+        for stop in route.get('stops', []):
+            s = Stop(stop_id=stop['id'], region_id=region.id,
+                     name=stop.get('name'),
+                     lat=stop.get('lat'),
+                     lon=stop.get('lon'))
+            db.session.merge(s)
+    db.session.commit()
+    print(f"Imported JSON for {region_name}")
+
+
+if __name__ == '__main__':
+    with app.app_context():
+        load_json(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Summary
- set up Flask app with SQLAlchemy and Flask-Login
- add models for regions, routes, stops, trips, stop times, and users
- implement login/logout endpoints using hashed passwords
- provide API endpoints for regions, routes, and stops
- add GTFS and JSON import scripts
- document usage and installation steps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849fcad70ac8332bfe1770e74207ed0