### PR TITLE
Add Flask GTFS API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DB_USER=postgres
+DB_PASSWORD=clave123
+DB_NAME=rutasnica
+DB_HOST=localhost
+DB_PORT=5432
+DB_DIALECT=postgresql

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.env
+*.sqlite3

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # rutasnicaragua
-todas las rutas y viejas de nicaragua en una sola pagina 
+
+Aplicaci\u00f3n Flask que expone informaci\u00f3n de rutas de transporte p\u00fablico usando datos GTFS.
+
+## Instalaci\u00f3n
+
+1. Instale las dependencias:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Copie `.env.example` a `.env` y modifique la configuraci\u00f3n de la base de datos.
+
+3. Cargue los archivos GTFS ubicados en `data/gtfs/` ejecutando:
+
+```bash
+python load_gtfs.py
+```
+
+4. Inicie la API:
+
+```bash
+python app.py
+```
+
+## Endpoints
+
+- `GET /api/regiones`
+- `GET /api/rutas?region=Managua`
+- `GET /api/paradas?ruta=0501`

--- a/app.py
+++ b/app.py
@@ -1,0 +1,60 @@
+from flask import Flask, jsonify, request
+from models import db, Region, Route, Stop, Trip, StopTime
+from config import DATABASE_URI
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URI
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+
+    @app.route('/api/regiones', methods=['GET'])
+    def get_regiones():
+        regiones = Region.query.all()
+        return jsonify([{'id': r.id, 'name': r.name} for r in regiones])
+
+    @app.route('/api/rutas', methods=['GET'])
+    def get_rutas():
+        region_name = request.args.get('region')
+        query = Route.query
+        if region_name:
+            query = query.join(Region).filter(Region.name == region_name)
+        rutas = query.all()
+        return jsonify([
+            {
+                'route_id': r.route_id,
+                'region': r.region.name,
+                'short_name': r.short_name,
+                'long_name': r.long_name,
+                'type': r.type
+            } for r in rutas
+        ])
+
+    @app.route('/api/paradas', methods=['GET'])
+    def get_paradas():
+        ruta_id = request.args.get('ruta')
+        if not ruta_id:
+            return jsonify({'error': 'ruta parameter required'}), 400
+        stops = (
+            Stop.query.join(StopTime).join(Trip)
+            .filter(Trip.route_id == ruta_id)
+            .distinct()
+            .all()
+        )
+        return jsonify([
+            {
+                'stop_id': s.stop_id,
+                'name': s.name,
+                'lat': s.lat,
+                'lon': s.lon,
+                'region': s.region.name
+            } for s in stops
+        ])
+
+    return app
+
+
+if __name__ == '__main__':
+    app = create_app()
+    app.run(debug=True)

--- a/config.py
+++ b/config.py
@@ -1,0 +1,18 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DB_USER = os.getenv('DB_USER', 'user')
+DB_PASSWORD = os.getenv('DB_PASSWORD', '')
+DB_NAME = os.getenv('DB_NAME', 'database')
+DB_HOST = os.getenv('DB_HOST', 'localhost')
+DB_PORT = os.getenv('DB_PORT', '5432')
+DB_DIALECT = os.getenv('DB_DIALECT', 'sqlite')
+
+if DB_DIALECT == 'sqlite':
+    DATABASE_URI = f'sqlite:///{DB_NAME}.sqlite3'
+else:
+    DATABASE_URI = (
+        f"{DB_DIALECT}://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_NAME}"
+    )

--- a/load_gtfs.py
+++ b/load_gtfs.py
@@ -1,0 +1,92 @@
+import os
+import pandas as pd
+from flask import Flask
+from models import db, Region, Stop, Route, Trip, StopTime
+from config import DATABASE_URI
+
+GTFS_DIR = os.path.join('data', 'gtfs')
+
+
+def create_app():
+    app = Flask(__name__)
+    app.config['SQLALCHEMY_DATABASE_URI'] = DATABASE_URI
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db.init_app(app)
+    return app
+
+
+def load_data(app):
+    with app.app_context():
+        db.create_all()
+
+        # assume a default region if not present
+        region_name = os.getenv('DEFAULT_REGION', 'Managua')
+        region = Region.query.filter_by(name=region_name).first()
+        if not region:
+            region = Region(name=region_name)
+            db.session.add(region)
+            db.session.commit()
+
+        # stops
+        stops_path = os.path.join(GTFS_DIR, 'stops.txt')
+        if os.path.exists(stops_path):
+            stops_df = pd.read_csv(stops_path)
+            for _, row in stops_df.iterrows():
+                stop = Stop(
+                    stop_id=row['stop_id'],
+                    region_id=region.id,
+                    name=row['stop_name'],
+                    lat=row['stop_lat'],
+                    lon=row['stop_lon']
+                )
+                db.session.merge(stop)
+            db.session.commit()
+
+        # routes
+        routes_path = os.path.join(GTFS_DIR, 'routes.txt')
+        if os.path.exists(routes_path):
+            routes_df = pd.read_csv(routes_path)
+            for _, row in routes_df.iterrows():
+                route = Route(
+                    route_id=row['route_id'],
+                    region_id=region.id,
+                    short_name=row.get('route_short_name'),
+                    long_name=row.get('route_long_name'),
+                    type=row.get('route_type')
+                )
+                db.session.merge(route)
+            db.session.commit()
+
+        # trips
+        trips_path = os.path.join(GTFS_DIR, 'trips.txt')
+        if os.path.exists(trips_path):
+            trips_df = pd.read_csv(trips_path)
+            for _, row in trips_df.iterrows():
+                trip = Trip(
+                    trip_id=row['trip_id'],
+                    route_id=row['route_id'],
+                    service_id=row.get('service_id'),
+                    headsign=row.get('trip_headsign')
+                )
+                db.session.merge(trip)
+            db.session.commit()
+
+        # stop_times
+        stop_times_path = os.path.join(GTFS_DIR, 'stop_times.txt')
+        if os.path.exists(stop_times_path):
+            times_df = pd.read_csv(stop_times_path)
+            for _, row in times_df.iterrows():
+                st = StopTime(
+                    trip_id=row['trip_id'],
+                    stop_id=row['stop_id'],
+                    arrival_time=row.get('arrival_time'),
+                    departure_time=row.get('departure_time'),
+                    stop_sequence=row.get('stop_sequence')
+                )
+                db.session.add(st)
+            db.session.commit()
+
+
+if __name__ == '__main__':
+    app = create_app()
+    load_data(app)

--- a/models.py
+++ b/models.py
@@ -1,0 +1,54 @@
+from flask_sqlalchemy import SQLAlchemy
+
+
+db = SQLAlchemy()
+
+class Region(db.Model):
+    __tablename__ = 'regions'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String, unique=True, nullable=False)
+
+    stops = db.relationship('Stop', backref='region', lazy=True)
+    routes = db.relationship('Route', backref='region', lazy=True)
+
+
+class Stop(db.Model):
+    __tablename__ = 'stops'
+    stop_id = db.Column(db.String, primary_key=True)
+    region_id = db.Column(db.Integer, db.ForeignKey('regions.id'), nullable=False)
+    name = db.Column(db.String, nullable=False)
+    lat = db.Column(db.Float, nullable=False)
+    lon = db.Column(db.Float, nullable=False)
+
+    stop_times = db.relationship('StopTime', backref='stop', lazy=True)
+
+
+class Route(db.Model):
+    __tablename__ = 'routes'
+    route_id = db.Column(db.String, primary_key=True)
+    region_id = db.Column(db.Integer, db.ForeignKey('regions.id'), nullable=False)
+    short_name = db.Column(db.String)
+    long_name = db.Column(db.String)
+    type = db.Column(db.Integer)
+
+    trips = db.relationship('Trip', backref='route', lazy=True)
+
+
+class Trip(db.Model):
+    __tablename__ = 'trips'
+    trip_id = db.Column(db.String, primary_key=True)
+    route_id = db.Column(db.String, db.ForeignKey('routes.route_id'), nullable=False)
+    service_id = db.Column(db.String)
+    headsign = db.Column(db.String)
+
+    stop_times = db.relationship('StopTime', backref='trip', lazy=True)
+
+
+class StopTime(db.Model):
+    __tablename__ = 'stop_times'
+    id = db.Column(db.Integer, primary_key=True)
+    trip_id = db.Column(db.String, db.ForeignKey('trips.trip_id'), nullable=False)
+    stop_id = db.Column(db.String, db.ForeignKey('stops.stop_id'), nullable=False)
+    arrival_time = db.Column(db.String)
+    departure_time = db.Column(db.String)
+    stop_sequence = db.Column(db.Integer)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+flask_sqlalchemy
+psycopg2-binary
+python-dotenv
+pandas


### PR DESCRIPTION
## Summary
- create Flask models for GTFS data
- load GTFS data from `data/gtfs`
- expose `/api/regiones`, `/api/rutas` and `/api/paradas` endpoints
- document how to run the project
- add example `.env` and requirements file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a01f75d308332b54c17e61346aa3d